### PR TITLE
Rename links in operator metadata

### DIFF
--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -23,11 +23,11 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/hybridcloudpatterns/patterns-operator:0.0.17
-    createdAt: 2023-07-26 15:50:32
-    description: An operator to deploy and manage architecture patterns from https://hybrid-cloud-patterns.io
+    createdAt: 2023-08-24 23:22:17
+    description: An operator to deploy and manage architecture patterns from https://validatedpatterns.io
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    repository: https://github.com/hybrid-cloud-patterns/patterns-operator
+    repository: https://github.com/validatedpatterns/patterns-operator
   name: patterns-operator.v0.0.17
   namespace: placeholder
 spec:
@@ -162,7 +162,7 @@ spec:
         displayName: Version
         path: version
       version: v1alpha1
-  description: Deploys and manages architecture patterns from https://hybrid-cloud-patterns.io
+  description: Deploys and manages architecture patterns from https://validatedpatterns.io
   displayName: Validated Patterns Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADIAgMAAADQNkYNAAAAAXNSR0IArs4c6QAAAAxQTFRF+/v7IWSdx3A4LDpGRm1eQgAAAnhJREFUaN7t2Ltt5TAQhWFzBcGAE0WKnbsJqgQFYj1WKQwJVqGSVICA2fu+ehwM52DD1eRf8p+I/Pg477zzzvu3q0aeTDT55Ekz0+SbJ36hyS9PRFjheFKJsJU/edKIsJW/eeJF2Mq/PBFhKzueVFcysbOwpLmSmZ2FJf5KFnYWloiwlR1PqjuZ2Fk40tzJzM7CEX8nCzsLR0TYyo4n1ZNM7CwMaZ5kZmdhiH+ShZ2FISJsZceT6k0mdhY7ad5kZmexE/8mCzuLnYiwlR1PqjWZ2FmspFmTmZ3FSvyaLOwsViLCVnY8qbZkYmexkWZLZnYWG/FbsrCz2IgIW9nxpNqTiZ3FQpo9mdlZLMTvycLOYiEibGXHk+pIJnaWMmmOZGZnKRN/JAs7C/+OKd8fNFWBgI8B16nkC5C6QCIgvUp+AGkLJAEyqCQDEgokAxLUxoC4IhkB0Sp/AVIXSQREq/wDSFskCZBBbXwkoUgyIEFtfCDOQEZAOq3xgdQGEgHptcYH0hpIAmRQG+9JMJAMSFAb74gzkRGQTmu8I7WJREB6rfGOtCaSABnUxlsSTCQDEtTGG+KMZASk0xpvSG0kEZBea7whrZEkQAa18ZoEI8mABLXxijgzGQHptMYrUptJBKTXGq9IayYJkEFt/CbBTDIgQW38Io4gIyCd1vhFaoJEQHqt8Yu0BEmADGrjJwkEyYAEtfGDOIqMgHRa4wepKRIB6bXGD9JSJAEyqI3vJFAkAxLUxjfiSDIC0mmNb6QmSQSk1xrfSEuSBMigNr6SQJIMSFAbX4ijyQhIpzW+kJomEZBea3whLU0SIIPaOKcQCsOcd955/9f9BYUNIA2v1ub2AAAAAElFTkSuQmCC
@@ -396,7 +396,7 @@ spec:
   - Architecture
   links:
   - name: Hybrid Cloud Patterns
-    url: https://hybrid-cloud-patterns.io
+    url: https://validatedpatterns.io
   maintainers:
   - email: hybrid-cloud-patterns@googlegroups.com
     name: patterns-team

--- a/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/hybridcloudpatterns/patterns-operator:0.0.1
-    description: An operator to deploy and manage architecture patterns from https://hybrid-cloud-patterns.io
-    repository: https://github.com/hybrid-cloud-patterns/patterns-operator
+    description: An operator to deploy and manage architecture patterns from https://validatedpatterns.io
+    repository: https://github.com/validatedpatterns/patterns-operator
   name: patterns-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -142,7 +142,7 @@ spec:
         displayName: Version
         path: version
       version: v1alpha1
-  description: Deploys and manages architecture patterns from https://hybrid-cloud-patterns.io
+  description: Deploys and manages architecture patterns from https://validatedpatterns.io
   displayName: Validated Patterns Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADIAgMAAADQNkYNAAAAAXNSR0IArs4c6QAAAAxQTFRF+/v7IWSdx3A4LDpGRm1eQgAAAnhJREFUaN7t2Ltt5TAQhWFzBcGAE0WKnbsJqgQFYj1WKQwJVqGSVICA2fu+ehwM52DD1eRf8p+I/Pg477zzzvu3q0aeTDT55Ekz0+SbJ36hyS9PRFjheFKJsJU/edKIsJW/eeJF2Mq/PBFhKzueVFcysbOwpLmSmZ2FJf5KFnYWloiwlR1PqjuZ2Fk40tzJzM7CEX8nCzsLR0TYyo4n1ZNM7CwMaZ5kZmdhiH+ShZ2FISJsZceT6k0mdhY7ad5kZmexE/8mCzuLnYiwlR1PqjWZ2FmspFmTmZ3FSvyaLOwsViLCVnY8qbZkYmexkWZLZnYWG/FbsrCz2IgIW9nxpNqTiZ3FQpo9mdlZLMTvycLOYiEibGXHk+pIJnaWMmmOZGZnKRN/JAs7C/+OKd8fNFWBgI8B16nkC5C6QCIgvUp+AGkLJAEyqCQDEgokAxLUxoC4IhkB0Sp/AVIXSQREq/wDSFskCZBBbXwkoUgyIEFtfCDOQEZAOq3xgdQGEgHptcYH0hpIAmRQG+9JMJAMSFAb74gzkRGQTmu8I7WJREB6rfGOtCaSABnUxlsSTCQDEtTGG+KMZASk0xpvSG0kEZBea7whrZEkQAa18ZoEI8mABLXxijgzGQHptMYrUptJBKTXGq9IayYJkEFt/CbBTDIgQW38Io4gIyCd1vhFaoJEQHqt8Yu0BEmADGrjJwkEyYAEtfGDOIqMgHRa4wepKRIB6bXGD9JSJAEyqI3vJFAkAxLUxjfiSDIC0mmNb6QmSQSk1xrfSEuSBMigNr6SQJIMSFAbX4ijyQhIpzW+kJomEZBea3whLU0SIIPaOKcQCsOcd955/9f9BYUNIA2v1ub2AAAAAElFTkSuQmCC
@@ -167,7 +167,7 @@ spec:
   - Architecture
   links:
   - name: Hybrid Cloud Patterns
-    url: https://hybrid-cloud-patterns.io
+    url: https://validatedpatterns.io
   maintainers:
   - email: hybrid-cloud-patterns@googlegroups.com
     name: patterns-team


### PR DESCRIPTION
Reflect the links move from hybrid-cloud-patterns.io to
validatedpatterns.io
