### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/push-built-tag.yml
+++ b/.github/workflows/push-built-tag.yml
@@ -1,0 +1,48 @@
+---
+name: vp-patterns/update-quay-image
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build_and_push_image:
+    name: Build and push pattern-operator image to quay.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check that tag version corresponds to metadata version
+        run: |-
+          VERSION=$(yq -r '.spec.version' bundle/manifests/patterns-operator.clusterserviceversion.yaml)
+          TAG=${{ github.ref_name }}
+          if [ "${VERSION}" != "${TAG}" ]; then
+            echo "Version in metadata ${VERSION} whereas tag is different: ${TAG}"
+            exit 1
+          fi
+
+      - name: Check that both QUAY_ROBOT_USER and QUAY_ROBOT_TOKEN exist
+        run: |-
+          failed=0
+          if [ -z "${{ secrets.QUAY_ROBOT_USER }}" ]; then
+            echo "QUAY_ROBOT_USER secret missing"
+            failed=1
+          fi
+          if [ -z "${{ secrets.QUAY_ROBOT_TOKEN }}" ]; then
+            echo "QUAY_ROBOT_TOKEN secret missing"
+            failed=1
+          fi
+          if [ ${failed} -eq 1 ]; then
+            echo "Erroring out due to missing secrets"
+            exit 1
+          fi
+
+      - name: Build container and push it to quay.io
+        run: |-
+          set -e
+          export VERSION=$(yq -r '.spec.version' bundle/manifests/patterns-operator.clusterserviceversion.yaml)
+          export REPO="quay.io/hybridcloudpatterns/patterns-operator"
+          make docker-build
+          echo "${{ secrets.QUAY_ROBOT_TOKEN }}" | docker login -u="${{ secrets.QUAY_ROBOT_USER }}" --password-stdin quay.io
+          docker images
+          docker push "${REPO}:${VERSION}"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ manager
 /catalog/_template.yaml
 /config/samples/pattern-catalog-*.yaml
 bundle.Dockerfile
+**/apikey.txt


### PR DESCRIPTION
We disabled the build trigger in quay and we're moving the container
build steps here in a github action. It gets triggered only when we push
a tag.

Main reason is the added flexibility when building within github as
opposed to within quay.
