### PR TITLE
Store analytics info in the CR Status

### DIFF
--- a/api/v1alpha1/pattern_types.go
+++ b/api/v1alpha1/pattern_types.go
@@ -216,6 +216,10 @@ type PatternStatus struct {
 	Conditions []PatternCondition `json:"conditions,omitempty"`
 	//+operator-sdk:csv:customerresourcedefinitions:type=status
 	Applications []PatternApplicationInfo `json:"applications,omitempty"`
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	AnalyticsSent bool `json:"analyticsSent,omitempty"`
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	AnalyticsUUID string `json:"analyticsUUID,omitempty"`
 }
 
 // See: https://book.kubebuilder.io/reference/markers/crd.html

--- a/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -163,6 +163,10 @@ spec:
           status:
             description: PatternStatus defines the observed state of Pattern
             properties:
+              analyticsSent:
+                type: boolean
+              analyticsUUID:
+                type: string
               appClusterDomain:
                 type: string
               applications:

--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -144,6 +144,10 @@ spec:
         displayName: Use CSV
         path: gitOpsSpec.useCSV
       statusDescriptors:
+      - displayName: Analytics Sent
+        path: analyticsSent
+      - displayName: Analytics UUID
+        path: analyticsUUID
       - displayName: App Cluster Domain
         path: appClusterDomain
       - displayName: Cluster Domain

--- a/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -163,6 +163,10 @@ spec:
           status:
             description: PatternStatus defines the observed state of Pattern
             properties:
+              analyticsSent:
+                type: boolean
+              analyticsUUID:
+                type: string
               appClusterDomain:
                 type: string
               applications:

--- a/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
@@ -124,6 +124,10 @@ spec:
         displayName: Use CSV
         path: gitOpsSpec.useCSV
       statusDescriptors:
+      - displayName: Analytics Sent
+        path: analyticsSent
+      - displayName: Analytics UUID
+        path: analyticsUUID
       - displayName: App Cluster Domain
         path: appClusterDomain
       - displayName: Cluster Domain

--- a/controllers/analytics_test.go
+++ b/controllers/analytics_test.go
@@ -82,12 +82,12 @@ var _ = Describe("VpAnalytics", func() {
 	It("should not send pattern installation info as disabled is true", func() {
 		vpAnalytics.SendPatternInstallationInfo(pattern)
 
-		Expect(vpAnalytics.sentInstallInfo).To(BeFalse())
+		Expect(pattern.Status.AnalyticsSent).To(BeFalse())
 	})
 
 	It("should not send pattern update info as disabled is true", func() {
 		vpAnalytics.SendPatternUpdateInfo(pattern)
 
-		Expect(vpAnalytics.sentInstallInfo).To(BeFalse())
+		Expect(pattern.Status.AnalyticsSent).To(BeFalse())
 	})
 })


### PR DESCRIPTION
This avoid spurious analytics events

Tested with both the hard-coding of uuid and with the randomly generated
one and no spurious analytics events were observed after a pod restart.
