### PR TITLE
Switch MultiSource on by default

### DIFF
--- a/api/v1alpha1/pattern_types.go
+++ b/api/v1alpha1/pattern_types.go
@@ -116,7 +116,7 @@ type GitConfig struct {
 type MultiSourceConfig struct {
 	// (EXPERIMENTAL) Enable multi-source support when deploying the clustergroup argo application
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=7,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
-	// +kubebuilder:default:=false
+	// +kubebuilder:default:=true
 	Enabled bool `json:"enabled,omitempty"`
 
 	// The helm chart url to fetch the helm charts from in order to deploy the pattern

--- a/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -126,7 +126,7 @@ spec:
                       (Only used when developing the clustergroup helm chart)
                     type: string
                   enabled:
-                    default: false
+                    default: true
                     description: (EXPERIMENTAL) Enable multi-source support when deploying
                       the clustergroup argo application
                     type: boolean

--- a/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -126,7 +126,7 @@ spec:
                       (Only used when developing the clustergroup helm chart)
                     type: string
                   enabled:
-                    default: false
+                    default: true
                     description: (EXPERIMENTAL) Enable multi-source support when deploying
                       the clustergroup argo application
                     type: boolean


### PR DESCRIPTION
This is okay, because it only affects the initial clustergroup
chart. Other charts need to be migrated manually.
Tested on MCG.

Note that this only affects patterns installed via the UI.
