### PR TITLE
Drop defaults for clusterGroup chart

### DIFF
--- a/api/v1alpha1/pattern_types.go
+++ b/api/v1alpha1/pattern_types.go
@@ -119,16 +119,12 @@ type MultiSourceConfig struct {
 	// +kubebuilder:default:=true
 	Enabled bool `json:"enabled,omitempty"`
 
-	// The helm chart url to fetch the helm charts from in order to deploy the pattern
-	// Defaults to https://charts.validatedpatterns.io/
+	// The helm chart url to fetch the helm charts from in order to deploy the pattern. Defaults to https://charts.validatedpatterns.io/
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=8,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:multiSourceConfig.enabled:true"}
-	// +kubebuilder:default:="https://charts.validatedpatterns.io/"
 	HelmRepoUrl string `json:"helmRepoUrl,omitempty"`
 
-	// Which chart version for the clustergroup helm chart
-	// Defaults to "0.8.*"
+	// Which chart version for the clustergroup helm chart. Defaults to "0.8.*"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=9,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:multiSourceConfig.enabled:true"}
-	// +kubebuilder:default:="0.8.*"
 	ClusterGroupChartVersion string `json:"clusterGroupChartVersion,omitempty"`
 
 	// The url when deploying the clustergroup helm chart directly from a git repo

--- a/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -116,8 +116,7 @@ spec:
                       used when developing the clustergroup helm chart)
                     type: string
                   clusterGroupChartVersion:
-                    default: 0.8.*
-                    description: Which chart version for the clustergroup helm chart
+                    description: Which chart version for the clustergroup helm chart.
                       Defaults to "0.8.*"
                     type: string
                   clusterGroupGitRepoUrl:
@@ -131,9 +130,8 @@ spec:
                       the clustergroup argo application
                     type: boolean
                   helmRepoUrl:
-                    default: https://charts.validatedpatterns.io/
                     description: The helm chart url to fetch the helm charts from
-                      in order to deploy the pattern Defaults to https://charts.validatedpatterns.io/
+                      in order to deploy the pattern. Defaults to https://charts.validatedpatterns.io/
                     type: string
                 type: object
             required:

--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -93,7 +93,7 @@ spec:
       - displayName: Git Ops Config
         path: gitOpsSpec
       - description: The helm chart url to fetch the helm charts from in order to
-          deploy the pattern Defaults to https://charts.validatedpatterns.io/
+          deploy the pattern. Defaults to https://charts.validatedpatterns.io/
         displayName: Helm Repo Url
         path: multiSourceConfig.helmRepoUrl
         x-descriptors:
@@ -102,7 +102,7 @@ spec:
           PII information
         displayName: Analytics UUID
         path: analyticsUUID
-      - description: Which chart version for the clustergroup helm chart Defaults
+      - description: Which chart version for the clustergroup helm chart. Defaults
           to "0.8.*"
         displayName: Cluster Group Chart Version
         path: multiSourceConfig.clusterGroupChartVersion

--- a/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -116,8 +116,7 @@ spec:
                       used when developing the clustergroup helm chart)
                     type: string
                   clusterGroupChartVersion:
-                    default: 0.8.*
-                    description: Which chart version for the clustergroup helm chart
+                    description: Which chart version for the clustergroup helm chart.
                       Defaults to "0.8.*"
                     type: string
                   clusterGroupGitRepoUrl:
@@ -131,9 +130,8 @@ spec:
                       the clustergroup argo application
                     type: boolean
                   helmRepoUrl:
-                    default: https://charts.validatedpatterns.io/
                     description: The helm chart url to fetch the helm charts from
-                      in order to deploy the pattern Defaults to https://charts.validatedpatterns.io/
+                      in order to deploy the pattern. Defaults to https://charts.validatedpatterns.io/
                     type: string
                 type: object
             required:

--- a/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
@@ -73,7 +73,7 @@ spec:
       - displayName: Git Ops Config
         path: gitOpsSpec
       - description: The helm chart url to fetch the helm charts from in order to
-          deploy the pattern Defaults to https://charts.validatedpatterns.io/
+          deploy the pattern. Defaults to https://charts.validatedpatterns.io/
         displayName: Helm Repo Url
         path: multiSourceConfig.helmRepoUrl
         x-descriptors:
@@ -82,7 +82,7 @@ spec:
           PII information
         displayName: Analytics UUID
         path: analyticsUUID
-      - description: Which chart version for the clustergroup helm chart Defaults
+      - description: Which chart version for the clustergroup helm chart. Defaults
           to "0.8.*"
         displayName: Cluster Group Chart Version
         path: multiSourceConfig.clusterGroupChartVersion


### PR DESCRIPTION
Reason for this is that we do not want the CRD to contain any default
and we let the operator pick a default when not set.

This makes it simpler to change version, because we only need to change
it in the operator and we do not need to update the CRD in common and
in all patterns.

Tested by installing an operator with this change and deploying via UI
(i.e. without a predefined default in the CRD) -> correctly deployed MCG
