### PR TITLE
Updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -181,8 +181,6 @@ require (
 )
 
 replace (
-	github.com/go-check/check => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
-	//	github.com/bombsimon/logrusr => github.com/bombsimon/logrusr v2.0.1
 	// Caused by Argo importing 'k8s.io/api'
 	// Override all the v0.0.0 entries
 	k8s.io/api => k8s.io/api v0.24.2
@@ -210,5 +208,4 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.24.2
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.2
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.2
-
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/argoproj/argo-cd/v2 v2.6.8
 	github.com/go-errors/errors v1.5.1
-	github.com/go-git/go-git/v5 v5.10.1
+	github.com/go-git/go-git/v5 v5.11.0
 	github.com/go-logr/logr v1.4.0
 	github.com/google/uuid v1.5.0
 	github.com/onsi/ginkgo/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -947,8 +947,8 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmS
 github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=
 github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
-github.com/go-git/go-git/v5 v5.10.1 h1:tu8/D8i+TWxgKpzQ3Vc43e+kkhXqtsZCKI/egajKnxk=
-github.com/go-git/go-git/v5 v5.10.1/go.mod h1:uEuHjxkHap8kAl//V5F/nNWwqIYtP/402ddd05mp0wg=
+github.com/go-git/go-git/v5 v5.11.0 h1:XIZc1p+8YzypNr34itUfSvYJcv+eYdTnTvOZ2vD3cA4=
+github.com/go-git/go-git/v5 v5.11.0/go.mod h1:6GFcX2P3NM7FPBfpePbpLd21XxsgdAt+lKqXmCUiUCY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/vendor/github.com/go-git/go-git/v5/config/branch.go
+++ b/vendor/github.com/go-git/go-git/v5/config/branch.go
@@ -54,7 +54,7 @@ func (b *Branch) Validate() error {
 		return errBranchInvalidRebase
 	}
 
-	return nil
+	return plumbing.NewBranchReferenceName(b.Name).Validate()
 }
 
 func (b *Branch) marshal() *format.Subsection {

--- a/vendor/github.com/go-git/go-git/v5/config/config.go
+++ b/vendor/github.com/go-git/go-git/v5/config/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5/internal/url"
+	"github.com/go-git/go-git/v5/plumbing"
 	format "github.com/go-git/go-git/v5/plumbing/format/config"
 )
 
@@ -614,7 +615,7 @@ func (c *RemoteConfig) Validate() error {
 		c.Fetch = []RefSpec{RefSpec(fmt.Sprintf(DefaultFetchRefSpec, c.Name))}
 	}
 
-	return nil
+	return plumbing.NewRemoteHEADReferenceName(c.Name).Validate()
 }
 
 func (c *RemoteConfig) unmarshal(s *format.Subsection) error {

--- a/vendor/github.com/go-git/go-git/v5/plumbing/object/patch.go
+++ b/vendor/github.com/go-git/go-git/v5/plumbing/object/patch.go
@@ -317,8 +317,8 @@ func getFileStatsFromFilePatches(filePatches []fdiff.FilePatch) FileStats {
 			// File is deleted.
 			cs.Name = from.Path()
 		} else if from.Path() != to.Path() {
-			// File is renamed. Not supported.
-			// cs.Name = fmt.Sprintf("%s => %s", from.Path(), to.Path())
+			// File is renamed.
+			cs.Name = fmt.Sprintf("%s => %s", from.Path(), to.Path())
 		} else {
 			cs.Name = from.Path()
 		}

--- a/vendor/github.com/go-git/go-git/v5/repository.go
+++ b/vendor/github.com/go-git/go-git/v5/repository.go
@@ -98,6 +98,10 @@ func InitWithOptions(s storage.Storer, worktree billy.Filesystem, options InitOp
 		options.DefaultBranch = plumbing.Master
 	}
 
+	if err := options.DefaultBranch.Validate(); err != nil {
+		return nil, err
+	}
+
 	r := newRepository(s, worktree)
 	_, err := r.Reference(plumbing.HEAD, false)
 	switch err {
@@ -724,7 +728,10 @@ func (r *Repository) DeleteBranch(name string) error {
 // CreateTag creates a tag. If opts is included, the tag is an annotated tag,
 // otherwise a lightweight tag is created.
 func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagOptions) (*plumbing.Reference, error) {
-	rname := plumbing.ReferenceName(path.Join("refs", "tags", name))
+	rname := plumbing.NewTagReferenceName(name)
+	if err := rname.Validate(); err != nil {
+		return nil, err
+	}
 
 	_, err := r.Storer.Reference(rname)
 	switch err {

--- a/vendor/github.com/go-git/go-git/v5/storage/filesystem/storage.go
+++ b/vendor/github.com/go-git/go-git/v5/storage/filesystem/storage.go
@@ -37,6 +37,10 @@ type Options struct {
 	// LargeObjectThreshold maximum object size (in bytes) that will be read in to memory.
 	// If left unset or set to 0 there is no limit
 	LargeObjectThreshold int64
+	// AlternatesFS provides the billy filesystem to be used for Git Alternates.
+	// If none is provided, it falls back to using the underlying instance used for
+	// DotGit.
+	AlternatesFS billy.Filesystem
 }
 
 // NewStorage returns a new Storage backed by a given `fs.Filesystem` and cache.
@@ -49,6 +53,7 @@ func NewStorage(fs billy.Filesystem, cache cache.Object) *Storage {
 func NewStorageWithOptions(fs billy.Filesystem, cache cache.Object, ops Options) *Storage {
 	dirOps := dotgit.Options{
 		ExclusiveAccess: ops.ExclusiveAccess,
+		AlternatesFS:    ops.AlternatesFS,
 	}
 	dir := dotgit.NewWithOptions(fs, dirOps)
 

--- a/vendor/github.com/go-git/go-git/v5/worktree.go
+++ b/vendor/github.com/go-git/go-git/v5/worktree.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/go-git/go-billy/v5"
@@ -95,7 +96,15 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 
 	head, err := w.r.Head()
 	if err == nil {
-		headAheadOfRef, err := isFastForward(w.r.Storer, ref.Hash(), head.Hash())
+		// if we don't have a shallows list, just ignore it
+		shallowList, _ := w.r.Storer.Shallow()
+
+		var earliestShallow *plumbing.Hash
+		if len(shallowList) > 0 {
+			earliestShallow = &shallowList[0]
+		}
+
+		headAheadOfRef, err := isFastForward(w.r.Storer, ref.Hash(), head.Hash(), earliestShallow)
 		if err != nil {
 			return err
 		}
@@ -104,7 +113,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 			return NoErrAlreadyUpToDate
 		}
 
-		ff, err := isFastForward(w.r.Storer, head.Hash(), ref.Hash())
+		ff, err := isFastForward(w.r.Storer, head.Hash(), ref.Hash(), earliestShallow)
 		if err != nil {
 			return err
 		}
@@ -188,7 +197,12 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 
 	return w.Reset(ro)
 }
+
 func (w *Worktree) createBranch(opts *CheckoutOptions) error {
+	if err := opts.Branch.Validate(); err != nil {
+		return err
+	}
+
 	_, err := w.r.Storer.Reference(opts.Branch)
 	if err == nil {
 		return fmt.Errorf("a branch named %q already exists", opts.Branch)
@@ -381,6 +395,9 @@ func (w *Worktree) resetWorktree(t *object.Tree) error {
 	b := newIndexBuilder(idx)
 
 	for _, ch := range changes {
+		if err := w.validChange(ch); err != nil {
+			return err
+		}
 		if err := w.checkoutChange(ch, t, b); err != nil {
 			return err
 		}
@@ -388,6 +405,104 @@ func (w *Worktree) resetWorktree(t *object.Tree) error {
 
 	b.Write(idx)
 	return w.r.Storer.SetIndex(idx)
+}
+
+// worktreeDeny is a list of paths that are not allowed
+// to be used when resetting the worktree.
+var worktreeDeny = map[string]struct{}{
+	// .git
+	GitDirName: {},
+
+	// For other historical reasons, file names that do not conform to the 8.3
+	// format (up to eight characters for the basename, three for the file
+	// extension, certain characters not allowed such as `+`, etc) are associated
+	// with a so-called "short name", at least on the `C:` drive by default.
+	// Which means that `git~1/` is a valid way to refer to `.git/`.
+	"git~1": {},
+}
+
+// validPath checks whether paths are valid.
+// The rules around invalid paths could differ from upstream based on how
+// filesystems are managed within go-git, but they are largely the same.
+//
+// For upstream rules:
+// https://github.com/git/git/blob/564d0252ca632e0264ed670534a51d18a689ef5d/read-cache.c#L946
+// https://github.com/git/git/blob/564d0252ca632e0264ed670534a51d18a689ef5d/path.c#L1383
+func validPath(paths ...string) error {
+	for _, p := range paths {
+		parts := strings.FieldsFunc(p, func(r rune) bool { return (r == '\\' || r == '/') })
+		if _, denied := worktreeDeny[strings.ToLower(parts[0])]; denied {
+			return fmt.Errorf("invalid path prefix: %q", p)
+		}
+
+		if runtime.GOOS == "windows" {
+			// Volume names are not supported, in both formats: \\ and <DRIVE_LETTER>:.
+			if vol := filepath.VolumeName(p); vol != "" {
+				return fmt.Errorf("invalid path: %q", p)
+			}
+
+			if !windowsValidPath(parts[0]) {
+				return fmt.Errorf("invalid path: %q", p)
+			}
+		}
+
+		for _, part := range parts {
+			if part == ".." {
+				return fmt.Errorf("invalid path %q: cannot use '..'", p)
+			}
+		}
+	}
+	return nil
+}
+
+// windowsPathReplacer defines the chars that need to be replaced
+// as part of windowsValidPath.
+var windowsPathReplacer *strings.Replacer
+
+func init() {
+	windowsPathReplacer = strings.NewReplacer(" ", "", ".", "")
+}
+
+func windowsValidPath(part string) bool {
+	if len(part) > 3 && strings.EqualFold(part[:4], GitDirName) {
+		// For historical reasons, file names that end in spaces or periods are
+		// automatically trimmed. Therefore, `.git . . ./` is a valid way to refer
+		// to `.git/`.
+		if windowsPathReplacer.Replace(part[4:]) == "" {
+			return false
+		}
+
+		// For yet other historical reasons, NTFS supports so-called "Alternate Data
+		// Streams", i.e. metadata associated with a given file, referred to via
+		// `<filename>:<stream-name>:<stream-type>`. There exists a default stream
+		// type for directories, allowing `.git/` to be accessed via
+		// `.git::$INDEX_ALLOCATION/`.
+		//
+		// For performance reasons, _all_ Alternate Data Streams of `.git/` are
+		// forbidden, not just `::$INDEX_ALLOCATION`.
+		if len(part) > 4 && part[4:5] == ":" {
+			return false
+		}
+	}
+	return true
+}
+
+func (w *Worktree) validChange(ch merkletrie.Change) error {
+	action, err := ch.Action()
+	if err != nil {
+		return nil
+	}
+
+	switch action {
+	case merkletrie.Delete:
+		return validPath(ch.From.String())
+	case merkletrie.Insert:
+		return validPath(ch.To.String())
+	case merkletrie.Modify:
+		return validPath(ch.From.String(), ch.To.String())
+	}
+
+	return nil
 }
 
 func (w *Worktree) checkoutChange(ch merkletrie.Change, t *object.Tree, idx *indexBuilder) error {
@@ -562,6 +677,11 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 }
 
 func (w *Worktree) checkoutFileSymlink(f *object.File) (err error) {
+	// https://github.com/git/git/commit/10ecfa76491e4923988337b2e2243b05376b40de
+	if strings.EqualFold(f.Name, gitmodulesFile) {
+		return ErrGitModulesSymlink
+	}
+
 	from, err := f.Reader()
 	if err != nil {
 		return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,7 +215,7 @@ github.com/go-git/go-billy/v5/helper/polyfill
 github.com/go-git/go-billy/v5/memfs
 github.com/go-git/go-billy/v5/osfs
 github.com/go-git/go-billy/v5/util
-# github.com/go-git/go-git/v5 v5.10.1
+# github.com/go-git/go-git/v5 v5.11.0
 ## explicit; go 1.19
 github.com/go-git/go-git/v5
 github.com/go-git/go-git/v5/config

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1502,7 +1502,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# github.com/go-check/check => github.com/go-check/check v0.0.0-20180628173108-788fd7840127
 # k8s.io/api => k8s.io/api v0.24.2
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.2
 # k8s.io/apimachinery => k8s.io/apimachinery v0.24.2


### PR DESCRIPTION
- Update go-git to v5.11.0
- Drop unneeded go-check replace statement
