### PR TITLE
Remove old locally checkout out folders if the target repo changes

### DIFF
--- a/controllers/checkout.go
+++ b/controllers/checkout.go
@@ -33,6 +33,8 @@ const (
 	GitAuthSsh      GitAuthenticationBackend = 2
 )
 
+const VPTmpFolder = "vp"
+
 type GitOperations interface {
 	CloneAndCheckout(repoURL, revision, localFolder string, gitAuth map[string][]byte) error
 }
@@ -100,7 +102,7 @@ func getLocalGitPath(repoURL string) (string, error) {
 	if normalizedGitURL == "" {
 		return "", fmt.Errorf("repository %q cannot be initialized: %w", repoURL, git.ErrInvalidRepoURL)
 	}
-	root := filepath.Join(os.TempDir(), r.ReplaceAllString(normalizedGitURL, "_"))
+	root := filepath.Join(os.TempDir(), VPTmpFolder, r.ReplaceAllString(normalizedGitURL, "_"))
 	if root == os.TempDir() {
 		return "", fmt.Errorf("repository %q cannot be initialized, because its root would be system temp at %s", repoURL, root)
 	}

--- a/controllers/pattern_controller_test.go
+++ b/controllers/pattern_controller_test.go
@@ -68,7 +68,7 @@ var _ = Describe("pattern controller", func() {
 
 		It("adding a pattern with origin, target and interval >-1", func() {
 			By("adding the pattern to the watch")
-			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/https___target.url", nil).Return(nil)
+			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/vp/https___target.url", nil).Return(nil)
 			_, _ = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: patternNamespaced})
 			Expect(watch.repoPairs).To(HaveLen(1))
 			Expect(watch.repoPairs[0].name).To(Equal(foo))
@@ -78,7 +78,7 @@ var _ = Describe("pattern controller", func() {
 
 		It("adding a pattern without origin Repository", func() {
 			p = &api.Pattern{}
-			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/https___target.url", nil).Return(nil)
+			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/vp/https___target.url", nil).Return(nil)
 			err := reconciler.Client.Get(context.Background(), patternNamespaced, p)
 			Expect(err).NotTo(HaveOccurred())
 			p.Spec.GitConfig.OriginRepo = ""
@@ -92,7 +92,7 @@ var _ = Describe("pattern controller", func() {
 
 		It("adding a pattern with interval == -1", func() {
 			p = &api.Pattern{}
-			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/https___target.url", nil).Return(nil)
+			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/vp/https___target.url", nil).Return(nil)
 			err := reconciler.Client.Get(context.Background(), patternNamespaced, p)
 			Expect(err).NotTo(HaveOccurred())
 			p.Spec.GitConfig.PollInterval = -1
@@ -105,7 +105,7 @@ var _ = Describe("pattern controller", func() {
 		})
 
 		It("validates changes to the poll interval in the manifest", func() {
-			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/https___target.url", nil).Return(nil).AnyTimes()
+			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/vp/https___target.url", nil).Return(nil).AnyTimes()
 
 			_, _ = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: patternNamespaced})
 			Expect(watch.repoPairs).To(HaveLen(1))
@@ -146,7 +146,7 @@ var _ = Describe("pattern controller", func() {
 		})
 
 		It("removes an existing pattern from the drift watcher by changing the originRepository to empty", func() {
-			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/https___target.url", nil).Return(nil).AnyTimes()
+			mockGitOps.EXPECT().CloneAndCheckout("https://target.url", "HEAD", "/tmp/vp/https___target.url", nil).Return(nil).AnyTimes()
 
 			_, _ = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: patternNamespaced})
 			Expect(watch.repoPairs).To(HaveLen(1))


### PR DESCRIPTION
Make sure the status local checkout path is always up to date as well.

Tested by cloning https://github.com/validatedpatterns/multicloud-gitops
and then changing the repo to
https://github.com/mbaldessari/multicloud-gitops.

Then observed that in the vp operator container in /tmp/vp/ only the
latter repo is the one inside. I.e. changing repo does not accumulated
cloned repos any longer
