### PR TITLE
Switch to gitops-1.11 as the default subscription channel

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -15,7 +15,7 @@ const (
 
 // GitOps Subscription
 const (
-	GitOpsDefaultChannel                = "gitops-1.8"
+	GitOpsDefaultChannel                = "gitops-1.11"
 	GitOpsDefaultPackageName            = "openshift-gitops-operator"
 	GitOpsDefaultCatalogSource          = "redhat-operators"
 	GitOpsDefaultCatalogSourceNamespace = "openshift-marketplace"


### PR DESCRIPTION
It is the latest gitops version that is present in ocp 4.12 which is the
oldest supported ocp version at this point in time.
