### PR TITLE
Add role to controller-manager serviceaccount

### DIFF
--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -10,3 +10,16 @@ subjects:
 - kind: ServiceAccount
   name: controller-manager
   namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
This allows us to use namespaced RBACs as well as clusterwide once
