### PR TITLE
Add code to check for the existance of the proper ArgoCD CRD version

### DIFF
--- a/controllers/pattern_controller.go
+++ b/controllers/pattern_controller.go
@@ -227,7 +227,7 @@ func (r *PatternReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// We only update the clusterwide argo instance so we can define our own 'initcontainers' section
-	err = createOrUpdateArgoCD(r.dynamicClient, ClusterWideArgoName, clusterWideNS)
+	err = createOrUpdateArgoCD(r.dynamicClient, r.config, ClusterWideArgoName, clusterWideNS)
 	if err != nil {
 		return r.actionPerformed(qualifiedInstance, "created or updated clusterwide argo instance", err)
 	}


### PR DESCRIPTION
This way the error when we have a gitops installation that is too old is
more comprehensible:

    2024/06/18 11:18:11 Reconcile step "created or updated clusterwide argo instance" failed: cannot find a sufficiently recent argocd crd version: API version argoproj.io/v1beta1 not available
    2024/06/18 11:18:11 Requeueing
    2024-06-18T11:18:11Z ERROR Reconciler error {"controller": "pattern", "controllerGroup": "gitops.hybrid-cloud-patterns.io", "controllerKind": "Pattern", "Pattern": {"name":"pattern-sample","namespace":"openshift-operators"}, "namespace": "openshift-operators", "name": "pattern-sample", "reconcileID": "e252ddf7-91ff-4801-a065-92cf0a94bdab", "error": "cannot find a sufficiently recent argocd crd version: API version argoproj.io/v1beta1 not available"}
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
    /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
    /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
    /workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235
    2024-06-18T11:19:33Z INFO Reconciling Pattern {"controller": "pattern", "controllerGroup": "gitops.hybrid-cloud-patterns.io", "controllerKind": "Pattern", "Pattern": {"name":"pattern-sample","namespace":"openshift-operators"}, "namespace": "openshift-operators", "name": "pattern-sample", "reconcileID": "ff929085-e8a3-4a03-badb-3dc5f7473246"}
