### PR TITLE
Build fixes and argo update

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Then switch to the `patterns-operator` git folder, define the version and create
 cd ../patterns-operator
 export VERSION=0.0.5
 git checkout -b "patterns-operator-v$VERSION"
-CHANNELS=fast make bundle
+CHANNELS=fast USE_IMAGE_DIGESTS=true make bundle
 git commit -a -m "Upgrade version to ${VERSION}"
 gh pr create
 # Merge the PR

--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -481,6 +481,4 @@ spec:
       name: kube-rbac-proxy
     - image: quay.io/hybridcloudpatterns/patterns-operator@sha256:e09fbb38429be15a57d675f03e1748fbce95b5545e0cdf28028e76ca4921751a
       name: manager
-    - image: quay.io/hybridcloudpatterns/patterns-operator@sha256:92f5e9e077a7766240d7d5afdce2032f030b89d3e4983ae099ef0208cea86723
-      name: patterns-operator-92f5e9e077a7766240d7d5afdce2032f030b89d3e4983ae099ef0208cea86723-annotation
   version: 0.0.53

--- a/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: OpenShift Optional
-    containerImage: quay.io/hybridcloudpatterns/patterns-operator:0.0.1
+    containerImage: ""
     description: "An operator to deploy and manage architecture patterns from https://validatedpatterns.io.
       \nThis operator collects some Analytics like cluster version, cloud type, etc.
       To disable this\nadd \"ANALYTICS: false\" to the environment variables in the

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	code.gitea.io/sdk/gitea v0.18.0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/argoproj-labs/argocd-operator v0.11.0
-	github.com/argoproj/argo-cd/v2 v2.11.4
+	github.com/argoproj/argo-cd/v2 v2.11.6
 	github.com/go-errors/errors v1.5.1
 	github.com/go-git/go-git/v5 v5.12.0
 	github.com/go-logr/logr v1.4.2
@@ -41,7 +41,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
-	github.com/argoproj/gitops-engine v0.7.1-0.20240702153804-5995eca2fb63 // indirect
+	github.com/argoproj/gitops-engine v0.7.1-0.20240715141605-18ba62e1f1fb // indirect
 	github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -644,10 +644,10 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/argoproj-labs/argocd-operator v0.11.0 h1:kercYZTGl4RikAKcDZIzpgBnGYESFtDK6CF+2w/f1MA=
 github.com/argoproj-labs/argocd-operator v0.11.0/go.mod h1:ZISiL0XVjBepV2vyXySVtqxowXjrHzyXbDmtZrSbz5o=
-github.com/argoproj/argo-cd/v2 v2.11.4 h1:ADwC/pbRkAo4RQ0txHaMpd//yn0ZD/GkKuGXOkBa9bg=
-github.com/argoproj/argo-cd/v2 v2.11.4/go.mod h1:0H0h5kihqrTC5TiRxFkgE/IHirSN2bJ8JJVo3mMepnU=
-github.com/argoproj/gitops-engine v0.7.1-0.20240702153804-5995eca2fb63 h1:HsXZiXycvpK/+HENrSyUEGnH1afvvPJiBfbQowwbRXg=
-github.com/argoproj/gitops-engine v0.7.1-0.20240702153804-5995eca2fb63/go.mod h1:d4eLldeEFyZIcVySAMhXhnh1tTa4qfvPYfut9B8UClw=
+github.com/argoproj/argo-cd/v2 v2.11.6 h1:rAqp1oduTOaugPjlhmjDmjY+zf1chBEX/5SQZItXDcY=
+github.com/argoproj/argo-cd/v2 v2.11.6/go.mod h1:RfmtLRki6JBwq9jkgCMie9MzfvYqs0DfzbuG3JcDrPk=
+github.com/argoproj/gitops-engine v0.7.1-0.20240715141605-18ba62e1f1fb h1:PbngWUqmtdVxU5qRR0Dngeo6AXhxY3qZi6RlpfCLbuI=
+github.com/argoproj/gitops-engine v0.7.1-0.20240715141605-18ba62e1f1fb/go.mod h1:d4eLldeEFyZIcVySAMhXhnh1tTa4qfvPYfut9B8UClw=
 github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1 h1:qsHwwOJ21K2Ao0xPju1sNuqphyMnMYkyB3ZLoLtxWpo=
 github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1/go.mod h1:CZHlkyAD1/+FbEn6cB2DQTj48IoLGvEYsWEvtzP3238=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -61,7 +61,7 @@ github.com/ProtonMail/go-crypto/openpgp/s2k
 ## explicit; go 1.21
 github.com/argoproj-labs/argocd-operator/api/v1beta1
 github.com/argoproj-labs/argocd-operator/common
-# github.com/argoproj/argo-cd/v2 v2.11.4
+# github.com/argoproj/argo-cd/v2 v2.11.6
 ## explicit; go 1.21
 github.com/argoproj/argo-cd/v2/common
 github.com/argoproj/argo-cd/v2/pkg/apis/application
@@ -87,7 +87,7 @@ github.com/argoproj/argo-cd/v2/util/io/path
 github.com/argoproj/argo-cd/v2/util/log
 github.com/argoproj/argo-cd/v2/util/proxy
 github.com/argoproj/argo-cd/v2/util/security
-# github.com/argoproj/gitops-engine v0.7.1-0.20240702153804-5995eca2fb63
+# github.com/argoproj/gitops-engine v0.7.1-0.20240715141605-18ba62e1f1fb
 ## explicit; go 1.19
 github.com/argoproj/gitops-engine/internal/kubernetes_vendor/pkg/api/v1/endpoints
 github.com/argoproj/gitops-engine/internal/kubernetes_vendor/pkg/util/hash


### PR DESCRIPTION
- **Use a locally downloaded operator-sdk**
- **Drop the default containerImage from annotations**
- **Document USE_IMAGE_DIGESTS=true in the first call to make bundle**
- **Upgrade argo to 2.11.6**
