### PR TITLE
Switch to gitops-1.13 by default

### DIFF
--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -17,7 +17,7 @@ const (
 
 // GitOps Subscription
 const (
-	GitOpsDefaultChannel                = "gitops-1.12"
+	GitOpsDefaultChannel                = "gitops-1.13"
 	GitOpsDefaultPackageName            = "openshift-gitops-operator"
 	GitOpsDefaultCatalogSource          = "redhat-operators"
 	GitOpsDefaultCatalogSourceNamespace = "openshift-marketplace"


### PR DESCRIPTION
It is supported all the way back to 4.12 at this point in time.
