### PR TITLE
Expose originURL as helm value

### DIFF
--- a/controllers/argo.go
+++ b/controllers/argo.go
@@ -361,6 +361,10 @@ func newApplicationParameters(p *api.Pattern) []argoapi.HelmParameter {
 			Value: p.Spec.GitConfig.TargetRepo,
 		},
 		{
+			Name:  "global.originURL",
+			Value: p.Spec.GitConfig.OriginRepo,
+		},
+		{
 			Name:  "global.targetRevision",
 			Value: p.Spec.GitConfig.TargetRevision,
 		},

--- a/controllers/argo_test.go
+++ b/controllers/argo_test.go
@@ -359,6 +359,10 @@ var _ = Describe("Argo Pattern", func() {
 						ForceString: false,
 					},
 					{
+						Name:  "global.originURL",
+						Value: "",
+					},
+					{
 						Name:        "global.targetRevision",
 						Value:       "main",
 						ForceString: false,


### PR DESCRIPTION
It is useful to know, because if this variable is set we know we've
spawned an incluster gitea instance

Tested via MCG on hub and spoke
