### PR TITLE
Switch to ubi-minimal for initcontainer image

### DIFF
--- a/controllers/argo.go
+++ b/controllers/argo.go
@@ -94,7 +94,7 @@ g, admin, role:admin`
 	initContainers := []v1.Container{
 		{
 			Name:  "fetch-ca",
-			Image: "registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest",
+			Image: "registry.redhat.io/ubi9/ubi-minimal:latest",
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "kube-root-ca",

--- a/controllers/argo_test.go
+++ b/controllers/argo_test.go
@@ -790,7 +790,7 @@ var _ = Describe("NewArgoCD", func() {
 			Expect(argoCD.Spec.Repo.InitContainers).To(HaveLen(1))
 			initContainer := argoCD.Spec.Repo.InitContainers[0]
 			Expect(initContainer.Name).To(Equal("fetch-ca"))
-			Expect(initContainer.Image).To(Equal("registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel9:latest"))
+			Expect(initContainer.Image).To(Equal("registry.redhat.io/ubi9/ubi-minimal:latest"))
 		})
 
 		It("should have the correct volumes", func() {


### PR DESCRIPTION
It is much smaller and since it literally only runs a cat command, we
best use a tiny image.

Tested successfully on MCG.
